### PR TITLE
fix

### DIFF
--- a/src/Boom.js
+++ b/src/Boom.js
@@ -263,7 +263,7 @@
 			if (!elemLength) {
 				return;
 			} else {
-				elem = elems.eq(imgLength++).show();
+				elem = elems.eq(imgLength++).css({"opacity":"1"});
 			}
 
 			if (imgLength == elemLength) {


### PR DESCRIPTION
当两个图片都消失后再点击boom,只会出现boom效果，原图没有显示出来
